### PR TITLE
Two example query templates

### DIFF
--- a/resources/sparql/protein/bioentity.mustache
+++ b/resources/sparql/protein/bioentity.mustache
@@ -1,0 +1,9 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX iaouniprot: <http://kabob.ucdenver.edu/iao/uniprot/>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+
+# Given a UniProt accession, the following query returns 
+# the bio-entity (protein) denoted by the accession:
+select (?bioentity as ?a) {
+         iaouniprot:UNIPROT_{{uniprot_acc}}_ICE obo:IAO_0000219 ?bioentity . # IAO:denotes
+}

--- a/resources/sparql/protein/processes.mustache
+++ b/resources/sparql/protein/processes.mustache
@@ -1,0 +1,15 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX iaouniprot: <http://kabob.ucdenver.edu/iao/uniprot/>
+PREFIX franzOption_clauseReorderer: <franz:identity>
+
+# Given a UniProt accession, the following query returns 
+# biological processes in which it participates:
+select (?bp as ?a) {
+         iaouniprot:UNIPROT_{{uniprot_acc}}_ICE obo:IAO_0000219 ?bioentity . # IAO:denotes
+  		 ?specificbioentity rdfs:subClassOf ?bioentity .
+         ?has_participant_r owl:someValuesFrom ?specificbioentity .
+         ?has_participant_r owl:onProperty obo:RO_0000057 . # RO:has_participant
+         ?specificbp rdfs:subClassOf ?has_participant_r .
+         ?specificbp rdfs:subClassOf ?bp .
+         ?bp rdfs:subClassOf* obo:GO_0008150 . # GO:biological_process       
+}


### PR DESCRIPTION
Included in the pull request are two example query templates. Both take a single parameter: a UniProt Accession ID, e.g. P15692

bioentity.mustache should return the KaBOB bioentity denoted by the UniProt Accession ID.
processes.mustache should return all biological processes in which the bioentity denoted by the UniProt Accession ID participates.

Note: these queries run successfully in the AG web UI, but hang in the query-cli. 